### PR TITLE
Builds the base nodejs Docker container using the Ansible role

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,12 @@ FROM inclusivedesign/centos:7
 
 RUN mkdir /etc/ansible/playbooks
 
-WORKDIR /opt/ansible/playbooks
+WORKDIR /etc/ansible/playbooks
 
-COPY ansible/requirements.yml requirements.yml
-
-COPY ansible/playbook-docker-build.yml playbook-docker-build.yml
+COPY ansible/* /etc/ansible/playbooks/
 
 RUN ansible-galaxy install -r requirements.yml
 
-RUN ansible-playbook playbook-docker-build.yml --tags "install"
+RUN ansible-playbook build.yml --tags "install"
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM inclusivedesign/centos:7
 
-RUN mkdir /opt/ansible
+RUN mkdir /etc/ansible/playbooks
 
-WORKDIR /opt/ansible
+WORKDIR /opt/ansible/playbooks
 
 COPY ansible/requirements.yml requirements.yml
 
 COPY ansible/playbook-docker-build.yml playbook-docker-build.yml
 
-RUN ansible-galaxy install-r requirements.yml
+RUN ansible-galaxy install -r requirements.yml
 
 RUN ansible-playbook playbook-docker-build.yml --tags "install"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM inclusivedesign/centos:7
 
-ENV NODEJS_VERSION 0.10.33
+RUN mkdir /opt/ansible
 
-RUN yum -y install nodejs-${NODEJS_VERSION} npm \
- && yum clean all
+WORKDIR /opt/ansible
+
+COPY ansible/requirements.yml requirements.yml
+
+COPY ansible/playbook-docker-build.yml playbook-docker-build.yml
+
+RUN ansible-galaxy install-r requirements.yml
+
+RUN ansible-playbook playbook-docker-build.yml --tags "install"
 
 CMD ["/bin/bash"]

--- a/ansible/build-vars.yml
+++ b/ansible/build-vars.yml
@@ -1,1 +1,6 @@
 # See https://github.com/idi-ops/ansible-nodejs/blob/master/defaults/main.yml for available variables
+# In the Docker build context, this one is our main interest, for building and
+# tagging different nodejs versions:
+#
+# Node.js version required by application (supported versions: 0.10.36*, 0.10.40, 4.2.0, 4.2.1)
+# nodejs_version: 0.10.36

--- a/ansible/build-vars.yml
+++ b/ansible/build-vars.yml
@@ -1,0 +1,1 @@
+# See https://github.com/idi-ops/ansible-nodejs/blob/master/defaults/main.yml for available variables

--- a/ansible/build.yml
+++ b/ansible/build.yml
@@ -1,6 +1,8 @@
 ---
 - hosts: local
   connection: local
+  vars_files:
+  - build-vars.yml
   roles:
   - ansible-facts
   - ansible-nodejs

--- a/ansible/build.yml
+++ b/ansible/build.yml
@@ -4,5 +4,5 @@
   vars_files:
   - build-vars.yml
   roles:
-  - ansible-facts
-  - ansible-nodejs
+  - facts
+  - nodejs

--- a/ansible/playbook-docker-build.yml
+++ b/ansible/playbook-docker-build.yml
@@ -1,0 +1,6 @@
+---
+- hosts: local
+  connection: local
+  roles:
+  - ansible-facts
+  - ansible-nodejs

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,2 @@
+- src: https://github.com/idi-ops/ansible-facts
+- src: https://github.com/idi-ops/ansible-nodejs

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,2 +1,4 @@
 - src: https://github.com/idi-ops/ansible-facts
+  name: facts
 - src: https://github.com/idi-ops/ansible-nodejs
+  name: nodejs


### PR DESCRIPTION
@avtar / @gtirloni , it would be good to review this one in somewhat more detail than the previous PR to the inclusivedesign/centos image - I want to make sure the change from 0.10.33 to 0.10.36 (the default version from the role) won't impact existing downstream containers.

I have tested this with my preferences server container at https://github.com/waharnum/docker-preferences-server but not otherwise.