### PR TITLE
0.10.41

### DIFF
--- a/ansible/build-vars.yml
+++ b/ansible/build-vars.yml
@@ -3,4 +3,4 @@
 # tagging different nodejs versions:
 #
 # Node.js version required by application (supported versions: 0.10.36*, 0.10.40, 4.2.0, 4.2.1)
-nodejs_version: 4.2.1
+nodejs_version: 0.10.41


### PR DESCRIPTION
Builds and runs fine with CentOS 7.1 / Docker 1.9.1:

    # docker run -ti nodejs:0.10.41 /usr/bin/node -v
    v0.10.41